### PR TITLE
Custom Record Naming version 1.5.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/tests/** linguist-vendored

--- a/.github/workflows/release-redcap-module.yml
+++ b/.github/workflows/release-redcap-module.yml
@@ -1,0 +1,18 @@
+# Create a release for a new version of a REDCap External Module, when a pull request with a version
+# number is merged into the main branch.
+
+name: Release REDCap Module
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  jobs:
+    name: Jobs
+    uses: Nottingham-CTU/Workflows/.github/workflows/release-redcap-module.yml@main
+

--- a/CustomRecordNaming.php
+++ b/CustomRecordNaming.php
@@ -1145,11 +1145,29 @@ class CustomRecordNaming extends \ExternalModules\AbstractExternalModule
 	// Exclude state tracking settings from settings exports.
 	public function exportProjectSettings()
 	{
+		$fnGetConfigFields = function ( $listConfig ) use ( &$fnGetConfigFields )
+		{
+			$listFields = [];
+			foreach ( $listConfig as $infoConfig )
+			{
+				if ( $infoConfig['type'] == 'sub_settings' )
+				{
+					$listFields += $fnGetConfigFields( $infoConfig['sub_settings'] );
+				}
+				else
+				{
+					$listFields[ $infoConfig['key'] ] = $infoConfig['key'];
+				}
+			}
+			return $listFields;
+		};
 		$this->getArmIdFromNum(1);
 		$listSettings = [];
+		$listSettingFields = $fnGetConfigFields( $this->getConfig()['project-settings'] );
 		$listFullSettings = $this->getProjectSettings();
-		foreach ( $listFullSettings as $key => $value )
+		foreach ( $listSettingFields as $key )
 		{
+			$value = $listFullSettings[ $key ];
 			if ( ! in_array( $key, [ 'enabled', 'scheme-settings',
 			                         'project-last-record', 'project-record-counter' ] ) )
 			{

--- a/config.json
+++ b/config.json
@@ -197,7 +197,7 @@
 		},
 		{
 			"key" : "project-record-counter",
-			"name" : "",
+			"name" : "Record counters (not for export)",
 			"type" : "text",
 			"super-users-only" : true
 		}

--- a/tests/dirname.txt
+++ b/tests/dirname.txt
@@ -1,0 +1,1 @@
+custom_record_naming


### PR DESCRIPTION
* The record counter setting is now labelled as not for export. This will help avoid confusion if the module settings are being exported using the export capability built in to REDCap, as the setting is flagged to the user as not exported. This does not affect the export/import capability provided as part of the module itself.
* The export of settings provided to other modules (e.g. the [Project Deployment](https://github.com/Nottingham-CTU/Project-Deployment) module) now provides the settings in a consistent order.